### PR TITLE
Cleanup.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.ts
 /cmd
+/vendor
+/go.sum

--- a/builder.go
+++ b/builder.go
@@ -227,7 +227,7 @@ func (g *Goty) addStructMembers(data *DataStruct, field reflect.Type) {
 			}
 		}
 
-		if elem.Anonymous {
+		if elem.Anonymous && elem.Type.Kind() == reflect.Struct {
 			// Extend the parent struct with a new struct.
 			data.Extends = append(data.Extends, member.Type)
 		} else {
@@ -325,7 +325,7 @@ func (g *Goty) parseSlice(parent *DataStruct, field reflect.Type, member *Struct
 
 // parseMap returns the typescript type for a given go map.
 func (g *Goty) parseMap(parent *DataStruct, field reflect.Type, member *StructMember) string {
-	// Parse both sides of tha map.
+	// Parse both sides of the map.
 	key, keyOptional := g.parseMember(parent, field.Key(), member)
 	val, valOptional := g.parseMember(parent, field.Elem(), member)
 

--- a/builder_test.go
+++ b/builder_test.go
@@ -1,7 +1,6 @@
 package goty_test
 
 import (
-	"testing"
 	"time"
 
 	"golift.io/goty"
@@ -16,16 +15,18 @@ type TestWrapper struct {
 		Username string `json:"username"`
 		Password string `json:"password"`
 	}
+	Config *goty.Config
 }
 
-var Weekdays = []time.Weekday{
-	time.Sunday,
-	time.Monday,
-	time.Tuesday,
-	time.Wednesday,
-	time.Thursday,
-	time.Friday,
-	time.Saturday,
+// Weekdays are cool.
+var Weekdays = []goty.Enum{
+	{Name: "Sunday", Value: time.Sunday},
+	{Name: "Monday", Value: time.Monday},
+	{Name: "Tuesday", Value: time.Tuesday},
+	{Name: "Wednesday", Value: time.Wednesday},
+	{Name: "Thursday", Value: time.Thursday},
+	{Name: "Friday", Value: time.Friday},
+	{Name: "Saturday", Value: time.Saturday},
 }
 
 type TestLevel1 struct {
@@ -38,11 +39,83 @@ type TestEndpoint struct {
 	APIKey string `json:"apiKey"`
 }
 
-// This test is incomplete.
-func TestBuilder(t *testing.T) {
-	t.Parallel()
-
+func ExampleGoty_Print() {
 	goty := goty.NewGoty(nil)
+	goty.Enums(Weekdays)
 	goty.Parse(TestWrapper{})
 	goty.Print()
+	// Output:
+	// /* Auto-generated. DO NOT EDIT. Generator: https://golift.io/goty
+	//  * Edit the source code and run goty again to make updates.
+	//  */
+	//
+	// /**
+	//  * @see golang: <time.Weekday>
+	//  */
+	// export enum Weekday {
+	//   Sunday    = 0,
+	//   Monday    = 1,
+	//   Tuesday   = 2,
+	//   Wednesday = 3,
+	//   Thursday  = 4,
+	//   Friday    = 5,
+	//   Saturday  = 6,
+	// };
+	//
+	// /**
+	//  * @see golang: <golift.io/goty_test.TestWrapper>
+	//  */
+	// export interface TestWrapper extends TestEndpoint {
+	//   Profile: TestLevel1;
+	//   Level1: TestLevel1;
+	//   EP?: TestEndpoint;
+	//   Auth: {
+	//     username: string;
+	//     password: string;
+	//   };
+	//   Config?: Config;
+	// };
+	//
+	// /**
+	//  * @see golang: <golift.io/goty_test.TestLevel1>
+	//  */
+	// export interface TestLevel1 {
+	//   name: string;
+	//   date: Date;
+	// };
+	//
+	// /**
+	//  * @see golang: <golift.io/goty_test.TestEndpoint>
+	//  */
+	// export interface TestEndpoint {
+	//   url: string;
+	//   apiKey: string;
+	// };
+	//
+	// /**
+	//  * @see golang: <golift.io/goty.Config>
+	//  */
+	// export interface Config {
+	//   overrides?: Record<null | any, Override>;
+	//   globalOverrides: Override;
+	// };
+	//
+	// /**
+	//  * @see golang: <golift.io/goty.Override>
+	//  */
+	// export interface Override {
+	//   type: string;
+	//   name: string;
+	//   optional: boolean;
+	//   tag: string;
+	//   comment: string;
+	//   keepBadChars: boolean;
+	//   keepUnderscores: boolean;
+	//   usePkgName: number;
+	//   noExport: boolean;
+	// };
+	//
+	// // Packages parsed:
+	// //   1. golift.io/goty
+	// //   2. golift.io/goty_test
 }

--- a/entry.go
+++ b/entry.go
@@ -35,11 +35,11 @@ const (
 type Config struct {
 	// Overrides is a map of go types to their typescript type and name.
 	// These override the global overrides.
-	Overrides Overrides
+	Overrides Overrides `json:"overrides" toml:"overrides" xml:"overrides" yaml:"overrides"`
 	// GlobalOverrides are applied to all structs unless a type-specific override exists.
-	GlobalOverrides Override
+	GlobalOverrides Override `json:"globalOverrides" toml:"global_overrides" xml:"global-override" yaml:"globalOverrides"`
 	// DocHandler is the handler for go/doc comments. Comments are off by default.
-	goatface.DocHandler
+	goatface.DocHandler `json:"-" toml:"-" xml:"-" yaml:"-"`
 }
 
 // Overrides is a map of go types to their typescript override values.
@@ -49,31 +49,34 @@ type Overrides map[any]Override
 type Override struct {
 	// Typescript type. ie. string, number, boolean, etc.
 	// This has no effect when set inside a global override; it's type specific.
-	Type string
+	Type string `json:"type" toml:"type" xml:"type" yaml:"type"`
 	// Typescript interface name. This does not work on field names.
 	// This has no effect when set inside a global override; it's type specific.
-	Name string
+	Name string `json:"name" toml:"name" xml:"name" yaml:"name"`
 	// Setting optional to true will add a question mark to the typescript name.
 	// This has no effect when set inside a global override; it's type specific.
-	Optional bool
+	Optional bool `json:"optional" toml:"optional" xml:"optional" yaml:"optional"`
 	// Tag is the tag name to use for the struct member(s). Default is "json".
-	Tag string
+	Tag string `json:"tag" toml:"tag" xml:"tag" yaml:"tag"`
 	// Comment is a comment to add to the typescript interface.
-	Comment string
+	Comment string `json:"comment" toml:"comment" xml:"comment" yaml:"comment"`
 	// Setting KeepBadChars to true will keep bad characters in the typescript name.
 	// These include pretty much all those characters on the number keys on your keyboard.
-	KeepBadChars bool
+	KeepBadChars bool `json:"keepBadChars" toml:"keep_bad_chars" xml:"keep-bad-chars" yaml:"keepBadChars"`
 	// Setting KeepUnderscores to true will keep underscores in the typescript name.
 	// Unlike other characters, underscores are valid. They are still removed by default.
-	KeepUnderscores bool
+	KeepUnderscores bool `json:"keepUnderscores" toml:"keep_underscores" xml:"keep-underscores" yaml:"keepUnderscores"`
 	// Configure the UsePkgName value to control how typescript interface names are generated.
-	UsePkgName UsePkgName
+	UsePkgName UsePkgName `json:"usePkgName" toml:"use_pkg_name" xml:"use-pkg-name" yaml:"usePkgName"`
 	// By default all typescript interfaces are exported. Set NoExport to true to prevent that.
-	NoExport bool
+	NoExport bool `json:"noExport" toml:"no_export" xml:"no-export" yaml:"noExport"`
 	// Namer is a function that can be used to customize the typescript interface name.
 	// Use this to add a prefix, suffix or any custom name changes you wish.
-	Namer func(refType reflect.Type, currentName string) string
+	Namer Namer `json:"-" toml:"-" xml:"-" yaml:"-"`
 }
+
+// Namer is an interface that allows external interface naming.
+type Namer func(refType reflect.Type, currentName string) string
 
 // NewGoty creates a new Goty instance to build typescript interfaces from go structs.
 // If config is nil, it will be initialized to an empty Override.

--- a/entry.go
+++ b/entry.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"slices"
 
-	"golift.io/goty/goatface"
+	"golift.io/goty/gotyface"
 )
 
 const (
@@ -39,7 +39,7 @@ type Config struct {
 	// GlobalOverrides are applied to all structs unless a type-specific override exists.
 	GlobalOverrides Override `json:"globalOverrides" toml:"global_overrides" xml:"global-override" yaml:"globalOverrides"`
 	// DocHandler is the handler for go/doc comments. Comments are off by default.
-	goatface.DocHandler `json:"-" toml:"-" xml:"-" yaml:"-"`
+	gotyface.DocHandler `json:"-" toml:"-" xml:"-" yaml:"-"`
 }
 
 // Overrides is a map of go types to their typescript override values.
@@ -47,19 +47,22 @@ type Overrides map[any]Override
 
 // Override is a struct that contains overrides for either a specific type or for all types (when global).
 type Override struct {
+	// Namer is a function that can be used to customize the typescript interface name.
+	// Use this to add a prefix, suffix or any custom name changes you wish.
+	Namer Namer `json:"-" toml:"-" xml:"-" yaml:"-"`
 	// Typescript type. ie. string, number, boolean, etc.
 	// This has no effect when set inside a global override; it's type specific.
 	Type string `json:"type" toml:"type" xml:"type" yaml:"type"`
 	// Typescript interface name. This does not work on field names.
 	// This has no effect when set inside a global override; it's type specific.
 	Name string `json:"name" toml:"name" xml:"name" yaml:"name"`
-	// Setting optional to true will add a question mark to the typescript name.
-	// This has no effect when set inside a global override; it's type specific.
-	Optional bool `json:"optional" toml:"optional" xml:"optional" yaml:"optional"`
 	// Tag is the tag name to use for the struct member(s). Default is "json".
 	Tag string `json:"tag" toml:"tag" xml:"tag" yaml:"tag"`
 	// Comment is a comment to add to the typescript interface.
 	Comment string `json:"comment" toml:"comment" xml:"comment" yaml:"comment"`
+	// Setting optional to true will add a question mark to the typescript name.
+	// This has no effect when set inside a global override; it's type specific.
+	Optional bool `json:"optional" toml:"optional" xml:"optional" yaml:"optional"`
 	// Setting KeepBadChars to true will keep bad characters in the typescript name.
 	// These include pretty much all those characters on the number keys on your keyboard.
 	KeepBadChars bool `json:"keepBadChars" toml:"keep_bad_chars" xml:"keep-bad-chars" yaml:"keepBadChars"`
@@ -70,9 +73,6 @@ type Override struct {
 	UsePkgName UsePkgName `json:"usePkgName" toml:"use_pkg_name" xml:"use-pkg-name" yaml:"usePkgName"`
 	// By default all typescript interfaces are exported. Set NoExport to true to prevent that.
 	NoExport bool `json:"noExport" toml:"no_export" xml:"no-export" yaml:"noExport"`
-	// Namer is a function that can be used to customize the typescript interface name.
-	// Use this to add a prefix, suffix or any custom name changes you wish.
-	Namer Namer `json:"-" toml:"-" xml:"-" yaml:"-"`
 }
 
 // Namer is an interface that allows external interface naming.
@@ -134,7 +134,7 @@ func (c *Config) setup() *Config {
 	c.GlobalOverrides.Name = ""
 
 	if c.DocHandler == nil {
-		c.DocHandler = goatface.NoDocs()
+		c.DocHandler = gotyface.NoDocs()
 	}
 
 	return c

--- a/entry.go
+++ b/entry.go
@@ -42,10 +42,10 @@ type Config struct {
 	goatface.DocHandler
 }
 
-// Overrides is a map of go types to their typescript type and name.
+// Overrides is a map of go types to their typescript override values.
 type Overrides map[any]Override
 
-// Override is a struct that contains the typescript type and name for a given go type.
+// Override is a struct that contains overrides for either a specific type or for all types (when global).
 type Override struct {
 	// Typescript type. ie. string, number, boolean, etc.
 	// This has no effect when set inside a global override; it's type specific.
@@ -61,11 +61,12 @@ type Override struct {
 	// Comment is a comment to add to the typescript interface.
 	Comment string
 	// Setting KeepBadChars to true will keep bad characters in the typescript name.
-	// These include dashes, periods,slashes, etc.
+	// These include pretty much all those characters on the number keys on your keyboard.
 	KeepBadChars bool
 	// Setting KeepUnderscores to true will keep underscores in the typescript name.
+	// Unlike other characters, underscores are valid. They are still removed by default.
 	KeepUnderscores bool
-	// Setting UsePkgName to true will prefix the typescript interface name with the package name.
+	// Configure the UsePkgName value to control how typescript interface names are generated.
 	UsePkgName UsePkgName
 	// By default all typescript interfaces are exported. Set NoExport to true to prevent that.
 	NoExport bool
@@ -88,13 +89,13 @@ func NewGoty(config *Config) *Goty {
 
 // Values returns the output of the builder.
 // These are raw values that can be used to generate typescript interfaces.
-// Only useful after calling .Enums() or .Parse().
+// Only useful after calling .Enums() and/or .Parse().
 func (g *Goty) Values() []*DataStruct {
 	return g.output
 }
 
 // Pkgs returns the list of package paths that we have parsed.
-// This is useful when you parse docs after you parse structs.
+// This is useful for parsing docs after parsing structs.
 func (g *Goty) Pkgs() []string {
 	output := make([]string, len(g.pkgPaths))
 	idx := 0
@@ -118,9 +119,7 @@ func getType(fld any) reflect.Type {
 	}
 }
 
-// setup converts the override map[any]string to map[reflect.Type]string.
-// This is done because the override map is more flexible, allowing
-// for overrides by base type or by reflect.Type.
+// setup makes sure the config is initialized and all defaults are set in the global override.
 func (c *Config) setup() *Config {
 	if c == nil {
 		c = &Config{}
@@ -139,6 +138,7 @@ func (c *Config) setup() *Config {
 }
 
 // setup makes sure an override has a tag value.
+// Other default override options are initially validated and configured here.
 func (o *Override) setup() *Override {
 	if o.Tag == "" {
 		o.Tag = DefaultTag // "json"

--- a/gotydoc/docs.go
+++ b/gotydoc/docs.go
@@ -12,7 +12,7 @@ import (
 	"reflect"
 	"strings"
 
-	"golift.io/goty/goatface"
+	"golift.io/goty/gotyface"
 )
 
 /* Lifted from here:
@@ -137,4 +137,4 @@ func (d *Docs) findDoc(typ reflect.Type) *doc.Type {
 }
 
 // Validate the interface implementation.
-var _ goatface.DocHandler = &Docs{}
+var _ gotyface.DocHandler = &Docs{}

--- a/gotyface/interface.go
+++ b/gotyface/interface.go
@@ -1,7 +1,7 @@
-// Package goatface holds the documentation interface for the goty packages.
+// Package gotyface holds the documentation interface for the goty packages.
 // It's a simple interface that allows you to pull go/doc comments into typescript as JSDoc.
 // Stored in a standalone package to avoid circular imports.
-package goatface
+package gotyface
 
 import "reflect"
 

--- a/gotyface/nodocs.go
+++ b/gotyface/nodocs.go
@@ -1,4 +1,4 @@
-package goatface
+package gotyface
 
 import "reflect"
 

--- a/notifiarrConfig.ts
+++ b/notifiarrConfig.ts
@@ -417,20 +417,20 @@ export interface NotiPlexConfig0 {
 };
 
 // Packages parsed:
-// - github.com/Notifiarr/notifiarr/pkg/apps
-// - github.com/Notifiarr/notifiarr/pkg/apps/apppkg/plex
-// - github.com/Notifiarr/notifiarr/pkg/apps/apppkg/sabnzbd
-// - github.com/Notifiarr/notifiarr/pkg/apps/apppkg/tautulli
-// - github.com/Notifiarr/notifiarr/pkg/configfile
-// - github.com/Notifiarr/notifiarr/pkg/logs
-// - github.com/Notifiarr/notifiarr/pkg/services
-// - github.com/Notifiarr/notifiarr/pkg/snapshot
-// - github.com/Notifiarr/notifiarr/pkg/triggers/commands
-// - github.com/Notifiarr/notifiarr/pkg/triggers/commands/cmdconfig
-// - github.com/Notifiarr/notifiarr/pkg/triggers/common/scheduler
-// - github.com/Notifiarr/notifiarr/pkg/triggers/endpoints/epconfig
-// - github.com/Notifiarr/notifiarr/pkg/triggers/filewatch
-// - golift.io/deluge
-// - golift.io/nzbget
-// - golift.io/qbit
-// - golift.io/starr
+//   1. github.com/Notifiarr/notifiarr/pkg/apps
+//   2. github.com/Notifiarr/notifiarr/pkg/apps/apppkg/plex
+//   3. github.com/Notifiarr/notifiarr/pkg/apps/apppkg/sabnzbd
+//   4. github.com/Notifiarr/notifiarr/pkg/apps/apppkg/tautulli
+//   5. github.com/Notifiarr/notifiarr/pkg/configfile
+//   6. github.com/Notifiarr/notifiarr/pkg/logs
+//   7. github.com/Notifiarr/notifiarr/pkg/services
+//   8. github.com/Notifiarr/notifiarr/pkg/snapshot
+//   9. github.com/Notifiarr/notifiarr/pkg/triggers/commands
+//  10. github.com/Notifiarr/notifiarr/pkg/triggers/commands/cmdconfig
+//  11. github.com/Notifiarr/notifiarr/pkg/triggers/common/scheduler
+//  12. github.com/Notifiarr/notifiarr/pkg/triggers/endpoints/epconfig
+//  13. github.com/Notifiarr/notifiarr/pkg/triggers/filewatch
+//  14. golift.io/deluge
+//  15. golift.io/nzbget
+//  16. golift.io/qbit
+//  17. golift.io/starr

--- a/printer.go
+++ b/printer.go
@@ -8,10 +8,11 @@ import (
 	"strings"
 )
 
-const header = `/* Auto-generated. DO NOT EDIT. Generator: https://golift.io/goty
+// Header is printed before anything else.
+const Header = `/* Auto-generated. DO NOT EDIT. Generator: https://golift.io/goty
  * Edit the source code and run goty again to make updates.` + "\n */\n\n"
 
-// ErrNoStructs is returned if no structs are found to write.
+// ErrNoStructs is returned if no structs are found to print or write.
 var ErrNoStructs = errors.New("no structs to write, run Parse() first")
 
 // Print prints all the structs in the output to stdout as typescript interfaces.
@@ -41,7 +42,7 @@ func (g *Goty) Write(fileName string, overwrite bool) error {
 	return nil
 }
 
-// Print prints a struct as a typescript interface.
+// Print a struct as a typescript interface to an io.Writer.
 func (s *DataStruct) Print(indent string, output io.Writer) {
 	golangRef := "\n * @see golang: <" + s.GoName + ">"
 	doc := formatDocs(false, indent, s.doc.Type(s.Type), s.ovr.Comment)
@@ -107,7 +108,7 @@ func (g *Goty) print(output io.Writer) {
 		panic(ErrNoStructs)
 	}
 
-	fmt.Fprint(output, header)
+	fmt.Fprint(output, Header)
 
 	for _, s := range g.output {
 		s.Print("", output)
@@ -119,8 +120,8 @@ func (g *Goty) print(output io.Writer) {
 
 	fmt.Fprintln(output, "// Packages parsed:")
 
-	for _, pkg := range g.Pkgs() {
-		fmt.Fprintln(output, "// - "+pkg)
+	for idx, pkg := range g.Pkgs() {
+		fmt.Fprintf(output, "// %3d. %s\n", idx+1, pkg)
 	}
 }
 

--- a/printer_test.go
+++ b/printer_test.go
@@ -106,9 +106,9 @@ func ExampleGoty_Print() {
 	// export interface Override {
 	//   type: string;
 	//   name: string;
-	//   optional: boolean;
 	//   tag: string;
 	//   comment: string;
+	//   optional: boolean;
 	//   keepBadChars: boolean;
 	//   keepUnderscores: boolean;
 	//   usePkgName: number;


### PR DESCRIPTION
- Fix comments, add a counter to pkg list. 
- Make `goty.Parse` and `goty.Enums` capable of taking in lists.
- Make the 1 test more useful, and rename the file.
- Add struct tags, and more struct comments.
- Only extend structs.
- Aligns all struts (using [betteralign](https://github.com/dkorunic/betteralign))