### PR TITLE
adjust some linter rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,20 +4,20 @@ linters:
   disable:
     - nlreturn
     - exhaustruct
-    - depguard
-  exclusions:
-    rules:
-      - path: "printer.go"
-        linters:
-          - forbidigo
-          - errcheck
-      - path: ".*_test.go"
-        linters:
-          - gochecknoglobals
-      - path: "cmd/"
-        linters:
-          - gochecknoglobals
-
+  settings:
+    errcheck:
+      disable-default-exclusions: true
+      exclude-functions:
+        - fmt.Fprint
+        - fmt.Fprintln
+        - fmt.Fprintf
+        - (*os.File).Close
+    depguard:
+      rules:
+        main:
+          allow:
+            - $gostd
+            - golift.io
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/builder.go
+++ b/builder.go
@@ -66,8 +66,6 @@ type StructMember struct {
 	Name string
 	// Type is the typescript type of the member. Usually string, number, boolean, etc.
 	Type string
-	// GoName is the full import path and name of the member.
-	GoName string
 	// Members is a list of members in this member if it's an anonymous struct.
 	Members []*StructMember
 	// Member is the struct field that we are building the typescript interface for.
@@ -132,7 +130,7 @@ func (g *Goty) enum(enum []Enum) {
 
 	data := &DataStruct{
 		Elements: make([]*Enum, len(enum)),
-		doc:      g.config.Docs,
+		doc:      g.config,
 		Type:     typ,
 		Name:     g.getStructName(typ),
 		GoName:   typ.PkgPath() + "." + typ.Name(),
@@ -178,7 +176,7 @@ func (g *Goty) parseStruct(elem reflect.Type) *DataStruct {
 		Type:    elem,
 		GoName:  elem.PkgPath() + "." + elem.Name(),
 		Members: make([]*StructMember, 0),
-		doc:     g.config.Docs,
+		doc:     g.config,
 		ovr:     g.config.override(elem),
 	}
 
@@ -211,18 +209,16 @@ func (g *Goty) addStructMembers(data *DataStruct, field reflect.Type) {
 		}
 
 		member := &StructMember{
-			Name:   g.stripBadChars(name, elem.Type),
-			doc:    g.config.Docs, // hard to attach this later.
-			Member: elem,
-			parent: data,
-			ovr:    ovr,
+			Name:     g.stripBadChars(name, elem.Type),
+			doc:      g.config, // hard to attach this later.
+			Member:   elem,
+			parent:   data,
+			ovr:      ovr,
+			Optional: ovr.Optional,
+			Type:     ovr.Type,
 		}
 
-		// Apply any 'type' overrides.
-		if ovr.Type != "" {
-			member.Type = ovr.Type
-			member.Optional = ovr.Optional
-		} else {
+		if member.Type == "" {
 			// We only parse the member if it didn't have a type override.
 			member.Type, member.Optional = g.parseMember(data, elem.Type, member)
 		}

--- a/entry.go
+++ b/entry.go
@@ -39,7 +39,7 @@ type Config struct {
 	// GlobalOverrides are applied to all structs unless a type-specific override exists.
 	GlobalOverrides Override `json:"globalOverrides" toml:"global_overrides" xml:"global-override" yaml:"globalOverrides"`
 	// DocHandler is the handler for go/doc comments. Comments are off by default.
-	gotyface.DocHandler `json:"-" toml:"-" xml:"-" yaml:"-"`
+	gotyface.Docs `json:"-" toml:"-" xml:"-" yaml:"-"`
 }
 
 // Overrides is a map of go types to their typescript override values.
@@ -133,8 +133,8 @@ func (c *Config) setup() *Config {
 	c.GlobalOverrides.Type = ""
 	c.GlobalOverrides.Name = ""
 
-	if c.DocHandler == nil {
-		c.DocHandler = gotyface.NoDocs()
+	if c.Docs == nil {
+		c.Docs = gotyface.NoDocs()
 	}
 
 	return c

--- a/gotydoc/docs.go
+++ b/gotydoc/docs.go
@@ -137,4 +137,4 @@ func (d *Docs) findDoc(typ reflect.Type) *doc.Type {
 }
 
 // Validate the interface implementation.
-var _ gotyface.DocHandler = &Docs{}
+var _ gotyface.Docs = &Docs{}

--- a/gotyface/interface.go
+++ b/gotyface/interface.go
@@ -5,8 +5,8 @@ package gotyface
 
 import "reflect"
 
-// DocHandler allows pulling go/doc comments into typescript as JSDoc.
-type DocHandler interface {
+// Docs allows pulling go/doc comments into typescript as JSDoc.
+type Docs interface {
 	// Type retrieves documentation for a type
 	Type(t reflect.Type) string
 

--- a/gotyface/nodocs.go
+++ b/gotyface/nodocs.go
@@ -21,4 +21,4 @@ func (n *noDocs) Member(_ reflect.Type, _ string) string {
 }
 
 // Validate the interface implementation.
-var _ DocHandler = &noDocs{}
+var _ Docs = &noDocs{}

--- a/printer_test.go
+++ b/printer_test.go
@@ -18,17 +18,6 @@ type TestWrapper struct {
 	Config *goty.Config
 }
 
-// Weekdays are cool.
-var Weekdays = []goty.Enum{
-	{Name: "Sunday", Value: time.Sunday},
-	{Name: "Monday", Value: time.Monday},
-	{Name: "Tuesday", Value: time.Tuesday},
-	{Name: "Wednesday", Value: time.Wednesday},
-	{Name: "Thursday", Value: time.Thursday},
-	{Name: "Friday", Value: time.Friday},
-	{Name: "Saturday", Value: time.Saturday},
-}
-
 type TestLevel1 struct {
 	Name string    `json:"name"`
 	Date time.Time `json:"date"`
@@ -40,8 +29,18 @@ type TestEndpoint struct {
 }
 
 func ExampleGoty_Print() {
+	weekdays := []goty.Enum{
+		{Name: "Sunday", Value: time.Sunday},
+		{Name: "Monday", Value: time.Monday},
+		{Name: "Tuesday", Value: time.Tuesday},
+		{Name: "Wednesday", Value: time.Wednesday},
+		{Name: "Thursday", Value: time.Thursday},
+		{Name: "Friday", Value: time.Friday},
+		{Name: "Saturday", Value: time.Saturday},
+	}
+
 	goty := goty.NewGoty(nil)
-	goty.Enums(Weekdays)
+	goty.Enums(weekdays)
 	goty.Parse(TestWrapper{})
 	goty.Print()
 	// Output:


### PR DESCRIPTION
- Adjust the linter to be more specific.
- Renames DocHandler interface to Docs.
- Refactor enum method a bit.