### PR TITLE
do not null slice pointers by default

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -318,7 +318,7 @@ func (g *Goty) parseSlice(parent *DataStruct, field reflect.Type, member *Struct
 	}
 
 	name, optional := g.parseMember(parent, field.Elem(), member)
-	if optional {
+	if optional && g.config.override(field).NullSlicePointers {
 		name = "(null | " + name + ")"
 	}
 

--- a/entry.go
+++ b/entry.go
@@ -46,6 +46,8 @@ type Config struct {
 type Overrides map[any]Override
 
 // Override is a struct that contains overrides for either a specific type or for all types (when global).
+//
+//nolint:lll // Can't break this up I don't think.
 type Override struct {
 	// Namer is a function that can be used to customize the typescript interface name.
 	// Use this to add a prefix, suffix or any custom name changes you wish.

--- a/entry.go
+++ b/entry.go
@@ -73,6 +73,9 @@ type Override struct {
 	UsePkgName UsePkgName `json:"usePkgName" toml:"use_pkg_name" xml:"use-pkg-name" yaml:"usePkgName"`
 	// By default all typescript interfaces are exported. Set NoExport to true to prevent that.
 	NoExport bool `json:"noExport" toml:"no_export" xml:"no-export" yaml:"noExport"`
+	// Setting NullSlicePointers to true causes the builder to add | null to slices of pointers.
+	// If your pointer slices are nullable, set this to true.
+	NullSlicePointers bool `json:"nullSlicePointers" toml:"null_slice_pointers" xml:"null-slice-pointers" yaml:"nullSlicePointers"`
 }
 
 // Namer is an interface that allows external interface naming.

--- a/printer_test.go
+++ b/printer_test.go
@@ -112,6 +112,7 @@ func ExampleGoty_Print() {
 	//   keepUnderscores: boolean;
 	//   usePkgName: number;
 	//   noExport: boolean;
+	//   nullSlicePointers: boolean;
 	// };
 	//
 	// // Packages parsed:


### PR DESCRIPTION
`(Struct | null)[]` sucks. This fixes it. If you like it the other way, pass true to the new override.

Example:
```
	goat := goty.NewGoty(&goty.Config{
		Docs: docs,
		GlobalOverrides: goty.Override{
			NullSlicePointers: true,
		},
		Overrides: goty.Overrides{
			cnfg.Duration{}:                 {Type: "string"},
			reflect.TypeOf(time.Weekday(0)): {Comment: "The day of the week."},
		},
	})
```